### PR TITLE
Improve sync/async API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+node_modules/
+npm-debug.log
+
 .DS_Store?
 ehthumbs.db
 Icon?

--- a/README.md
+++ b/README.md
@@ -1,75 +1,73 @@
-                    __           
-       __   _ __   /\_\    ____  
-     /'__`\/\`'__\ \/\ \  /',__\ 
+                    __
+       __   _ __   /\_\    ____
+     /'__`\/\`'__\ \/\ \  /',__\
     /\ \L\ \ \ \/__ \ \ \/\__, `\
     \ \___, \ \_\\_\_\ \ \/\____/
-     \/___/\ \/_//_/\ \_\ \/___/ 
-          \ \_\    \ \____/      
-           \/_/     \/___/       
+     \/___/\ \/_//_/\ \_\ \/___/
+          \ \_\    \ \____/
+           \/_/     \/___/
 
 [qr.js][] is a pure JavaScript library for [QR code][] generation using canvas.
 
 ## Standard Usage
 
 ``` javascript
-qr.canvas([data|value][, callback(error, canvas)])
-qr.image([data|value][, callback(error, image)])
-qr.toDataURL([data|value][, callback(error, url)])
-qr.save([data|value][, path][, callback(error)])
+qr.canvas([data|value])
+qr.image([data|value])
+qr.save([data|value][, path], callback(error))
+qr.saveSync([data|value][, path])
+qr.toDataURL([data|value])
 ```
 
 ### First Argument
 
-[qr.js][] allows either a `data` object or string `value` to be passed as the
-first argument. If a string is used all options will use their default value;
-otherwise they can be set using the following properties;
+[qr.js][] allows either a `data` object or string `value` to be passed as the first argument. If a
+string is used all options will use their default value; otherwise they can be set using the
+following properties;
 
-* `background` - *Optional:* The background colour to be used (defaults to
-  `"#fff"`).
-* `canvas` - *Optional:* The `<canvas>` element in which the QR code should be
-  rendered (creates a new `<canvas>` element by default).
-* `foreground` - *Optional:* The foreground colour to be used (defaults to
-  `"#000"`).
-* `image` - *Optional:* The `<img>` element in which the QR code should be
-  rendered (creates a new `<img>` element by default).
+* `background` - *Optional:* The background colour to be used (defaults to `"#fff"`).
+* `canvas` - *Optional:* The `<canvas>` element in which the QR code should be rendered (creates a
+  new `<canvas>` element by default).
+* `foreground` - *Optional:* The foreground colour to be used (defaults to `"#000"`).
+* `image` - *Optional:* The `<img>` element in which the QR code should be rendered (creates a new
+  `<img>` element by default).
   * This property is only used by `qr.image`.
-* `level` - *Optional:* The ECC (error correction capacity) level to be applied
-  (defaults to `"L"`).
+* `level` - *Optional:* The ECC (error correction capacity) level to be applied (defaults to
+  `"L"`).
+* `mime` - *Optional:* The MIME type to process the QR code image (defaults to `"image/png"`).
+  * The property is only used by `qr.image` and `qr.toDataURL` as well as `qr.save` and
+    `qr.saveSync` when running inside of a browser.
 * `path` - *Optional:* The path to which the QR code should be saved.
   * This property is only used by `qr.save`.
-  * This property is only required when running outside of a browser and is
-    ingored otherwise.
-* `size` - *Optional:* The module size of the generated QR code (defaults to
-  `4`).
-* `value` - *Optional:* The value to be encoded in the generated QR code
-  (defaults to `""`).
+  * This property is only required when running outside of a browser and is ingored otherwise.
+* `size` - *Optional:* The module size of the generated QR code (defaults to `4`).
+* `value` - *Optional:* The value to be encoded in the generated QR code (defaults to `""`).
 
 ## Miscellaneous
 
 ``` javascript
-qr.noConflict([callback(error)])
+qr.noConflict()
 qr.VERSION
 ```
 
 ## Bugs
 
-If you have any problems with this library or would like to see the changes
-currently in development you can do so here;
+If you have any problems with this library or would like to see the changes currently in
+development you can do so here;
 
 https://github.com/neocotic/qr.js/issues
 
 ## Questions?
 
-Take a look at `docs/qr.html` to get a better understanding of what the code is
-doing.
+Take a look at `docs/qr.html` to get a better understanding of what the code is doing.
 
 If that doesn't help, feel free to follow me on Twitter, [@neocotic][].
 
-However, if you want more information or examples of using this library please
-visit the project's homepage;
+However, if you want more information or examples of using this library please visit the project's
+homepage;
 
 http://neocotic.com/qr.js
 
-[@neocotic]: https://twitter.com/#!/neocotic
+[@neocotic]: https://twitter.com/neocotic
 [qr.js]: http://neocotic.com/qr.js
 [QR code]: http://en.wikipedia.org/wiki/QR_code

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "url": "git://github.com/neocotic/qr.js.git"
   },
   "dependencies": {
-    "canvas": "0.8"
+    "canvas": "~1.1.2"
   },
-  "main": "./qr.js"
+  "main": "qr.js"
 }


### PR DESCRIPTION
Removed unnecessary callbacks and simplified sync and async code (incl. new `saveSync` method).

This PR also fixes #16 by adding support for an optional `mime` option to the following methods to override the default `image/png` mime:
- `image`
- `save` (in browser)
- `saveSync` (in browser)
- `toDataURL`
