### PR TITLE
writeFileSync: close the fd on success.

### DIFF
--- a/qr.js
+++ b/qr.js
@@ -268,7 +268,7 @@
 
     try {
       fs.writeSync(fd, buff, 0, buff.length, 0);
-    } catch (error) {
+    } finally {
       fs.closeSync(fd);
     }
   }


### PR DESCRIPTION
  This patch force the file descriptor open by writeFileSync to be
  closed on success (it was closed only on write error).

  Our Node.js application was throwing `EMFILE, too many open files'
  because file descriptors open by writeFileSync were never released.
  Sadly, this kind of bug is too much setup and platform dependent to be
  tested (we discovered it in production).

  Sponsored by: Net Oxygen (http://netoxygen.ch)
