### PR TITLE
Add process.browser check for inNode

### DIFF
--- a/qr.js
+++ b/qr.js
@@ -1188,17 +1188,20 @@
 
   // Export `qr` for node.js and CommonJS.
   if (typeof exports !== 'undefined') {
-    inNode = true;
+    // Detect if we are using CommonJS *without* Node i.e. browserify
+    inNode = !(typeof process !== 'undefined' && process.browser); // browserify-specific check
 
     if (typeof module !== 'undefined' && module.exports) {
       exports = module.exports = qr;
     }
     exports.qr = qr;
-
-    // Import required node.js modules.
-    Canvas = require('canvas');
-    Image = Canvas.Image;
-    fs = require('fs');
+    
+    if (inNode) {
+      // Import required node.js modules.
+      Canvas = require('canvas');
+      Image = Canvas.Image;
+      fs = require('fs');
+    }
   } else if (typeof define === 'function' && define.amd) {
     define(function () {
       return qr;


### PR DESCRIPTION
This check allows people to use the module with Browserify. Otherwise it will attempt to load the node modules.